### PR TITLE
Wrap exceptions with 400 <= code < 600 to provide error message

### DIFF
--- a/server/public/index.php
+++ b/server/public/index.php
@@ -8,8 +8,8 @@ use Slim\Exception\HttpNotFoundException;
 use DI\Container;
 
 use Tuupola\Middleware\CorsMiddleware;
+use Cora\Middleware\HttpErrorMiddleware;
 
-use Cora\Repository;
 use Cora\Handler;
 use Cora\Utils;
 
@@ -41,9 +41,17 @@ $container->set(\PDO::class, function(ContainerInterface $container) {
 
 $app->addBodyParsingMiddleware();
 $app->addRoutingMiddleware();
-$app->addErrorMiddleware(true, true, true);
 
-$app->add(new CorsMiddleware([
+$errorHandlerMiddleware = new HttpErrorMiddleware(
+    $app->getCallableResolver(),
+    $app->getResponseFactory(),
+    false,
+    true,
+    true
+);
+$app->addMiddleware($errorHandlerMiddleware);
+
+$app->addMiddleware(new CorsMiddleware([
     "origin"        => ["*"],
     "methods"       => ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
     "headers.allow" => ["Content-Type", "Accept", "Origin",

--- a/server/src/Converter/JsonToGraph.php
+++ b/server/src/Converter/JsonToGraph.php
@@ -11,8 +11,7 @@ use Cora\Domain\Petrinet\Place\Place;
 use Cora\Domain\Petrinet\Marking\MarkingBuilder;
 use Cora\Domain\Petrinet\Marking\Tokens\IntegerTokenCount;
 use Cora\Domain\Petrinet\Marking\Tokens\OmegaTokenCount;
-
-use Exception;
+use Cora\Exception\BadInputException;
 
 class JsonToGraph extends Converter {
     protected $json;
@@ -27,7 +26,8 @@ class JsonToGraph extends Converter {
         $json = $this->json;
         if (!array_key_exists("states", $json) ||
             !array_key_exists("edges", $json))
-            throw new Exception("Could not parse graph: incorrect format");
+            throw new BadInputException(
+                "Could not parse graph: incorrect format");
 
         $builder = new GraphBuilder($this->petrinet);
         $this->addVertexes($builder);
@@ -42,7 +42,8 @@ class JsonToGraph extends Converter {
         foreach($states as $stateA) {
             if (!array_key_exists("state", $stateA) ||
                 !array_key_exists("id", $stateA))
-                throw new Exception("Could not parse graph: incorrect format");
+                throw new BadInputException(
+                    "Could not parse graph: incorrect format");
             $vertexId = intval($stateA["id"]);
             $marking = $this->stringToMarking($stateA["state"]);
             $builder->addVertex($vertexId, $marking);
@@ -56,7 +57,8 @@ class JsonToGraph extends Converter {
                 !array_key_exists("toId", $edgeA) ||
                 !array_key_exists("transition", $edgeA) ||
                 !array_key_exists("id", $edgeA))
-                throw new Exception("Could not parse graph: invalid format");
+                throw new BadInputException(
+                    "Could not parse graph: incorrect format");
             $from = intval($edgeA["fromId"]);
             $to = intval($edgeA["toId"]);
             $transition = trim($edgeA["transition"]);
@@ -70,7 +72,8 @@ class JsonToGraph extends Converter {
         $json = $this->json;
         if (array_key_exists("initial", $json)) {
             if (!array_key_exists("id", $json["initial"]))
-                throw new Exception("Could not parse graph: incorrect format");
+                throw new BadInputException(
+                    "Could not parse graph: incorrect format");
             if (is_null($json["initial"]["id"]))
                 $builder->setInitial(NULL);
             else {

--- a/server/src/Converter/LolaToPetrinet.php
+++ b/server/src/Converter/LolaToPetrinet.php
@@ -10,7 +10,7 @@ use Cora\Domain\Petrinet\Marking\Tokens\IntegerTokenCount;
 use Cora\Domain\Petrinet\Marking\MarkingBuilder;
 use Cora\Domain\Petrinet\MarkedPetrinet;
 
-use Exception;
+use Cora\Exception\BadInputException;
 
 class LolaToPetrinet extends Converter {
     protected $lola;
@@ -42,7 +42,7 @@ class LolaToPetrinet extends Converter {
         }
         $petrinet = $builder->getPetrinet();
         if (is_null($markingLine))
-            throw new Exception("Could not parse Lola: no marking");
+            throw new BadInputException("Could not parse Lola: no marking");
         $marking = $this->parseMarking($markingLine, $petrinet);
         return new MarkedPetrinet($petrinet, $marking);
     }

--- a/server/src/Converter/PetrinetTranslator.php
+++ b/server/src/Converter/PetrinetTranslator.php
@@ -9,9 +9,9 @@ use Cora\Domain\Petrinet\Place\Place;
 use Cora\Domain\Petrinet\Transition\Transition;
 use Cora\Domain\Petrinet\Flow\Flow;
 use Cora\Domain\Petrinet\Marking\MarkingBuilder;
+use Cora\Exception\BadInputException;
 
 use Ds\Map;
-use Exception;
 
 class PetrinetTranslator extends Converter {
     protected $markedPetrinet;
@@ -74,8 +74,8 @@ class PetrinetTranslator extends Converter {
                 $newFlow = new Flow($this->transitionTranslations->get($from),
                                     $this->placeTranslations->get($to));
             else
-                throw new Exception("Could not translate flows: " .
-                                    "misformed translations");
+                throw new BadInputException("Could not translate flows: " .
+                                            "misformed translations");
             $this->petrinetBuilder->addFlow($newFlow, $weight);
         }
     }

--- a/server/src/Domain/Graph/GraphBuilder.php
+++ b/server/src/Domain/Graph/GraphBuilder.php
@@ -6,9 +6,9 @@ use Cora\Domain\Graph\EdgeInterface as Edge;
 use Cora\Domain\Graph\GraphInterface as IGraph;
 use Cora\Domain\Petrinet\PetrinetInterface as IPetrinet;
 use Cora\Domain\Petrinet\Transition\Transition;
+use Cora\Exception\BadInputException;
 
 use Cora\Utils\SetUtils;
-use Exception;
 
 class GraphBuilder implements GraphBuilderInterface {
     protected $vertexes;
@@ -37,19 +37,21 @@ class GraphBuilder implements GraphBuilderInterface {
     public function getGraph(): IGraph {
         if (!is_null($this->initial) &&
             !$this->vertexes->hasVertex($this->initial))
-            throw new Exception("Could not create graph: initial id assigned " .
-                                "to non-vertex element");
+            throw new BadInputException("Could not create graph: initial id " .
+                                        "assigned to non-vertex element");
         $vertexIds = $this->vertexes->getIds();
         $edgeIds = $this->edges->getIds();
         if (!SetUtils::areDisjoint($vertexIds, $edgeIds))
-            throw new Exception("Could not create graph: conflicting ids");
+            throw new BadInputException("Could not create graph: vertex and " .
+                                        "edge ids are not disjoint");
         $transitions = $this->petrinet->getTransitions();
         foreach($this->edges as $edge) {
             $label = $edge->getLabel();
             $trans = new Transition($label);
             if (!$transitions->contains($trans))
-                throw new Exception("Could not create graph: graph labels do " .
-                                    "not correspond with Petrinet transitions");
+                throw new BadInputException("Could not create graph: graph " .
+                                            "labels do not correspond with " .
+                                            "Petri net transitions");
         }
         return new Graph($this->vertexes, $this->edges, $this->initial);
     }

--- a/server/src/Domain/Petrinet/Marking/MarkingBuilder.php
+++ b/server/src/Domain/Petrinet/Marking/MarkingBuilder.php
@@ -6,9 +6,9 @@ use Cora\Domain\Petrinet\Marking\MarkingInterface as IMarking;
 use Cora\Domain\Petrinet\Marking\Tokens\TokenCountInterface as Tokens;
 use Cora\Domain\Petrinet\PetrinetInterface as Petrinet;
 use Cora\Domain\Petrinet\Place\Place;
+use Cora\Exception\BadInputException;
 
 use Ds\Map;
-use Exception;
 
 class MarkingBuilder implements MarkingBuilderInterface {
     protected $map;
@@ -26,7 +26,7 @@ class MarkingBuilder implements MarkingBuilderInterface {
         $assignedPlaces = $this->map->keys();
         foreach($assignedPlaces as $place) {
             if (!$places->contains($place))
-                throw new Exception("Tokens assigned to invalid place");
+                throw new BadInputException("Tokens assigned to invalid place");
         }
         $marking = new Marking($this->map);
         return $marking;

--- a/server/src/Domain/Petrinet/PetrinetBuilder.php
+++ b/server/src/Domain/Petrinet/PetrinetBuilder.php
@@ -13,7 +13,7 @@ use Cora\Domain\Petrinet\Flow\FlowInterface as IFlow;
 use Cora\Domain\Petrinet\Flow\FlowMap;
 use Cora\Domain\Petrinet\Flow\FlowMapInterface;
 
-use Exception;
+use Cora\Exception\BadInputException;
 
 class PetrinetBuilder implements PetrinetBuilderInterface {
     protected $places;
@@ -64,9 +64,9 @@ class PetrinetBuilder implements PetrinetBuilderInterface {
                   $this->places->contains($from) && $this->transitions->contains($to)) &&
                 !($from instanceof Transition && $to instanceof Place &&
                   $this->transitions->contains($from) && $this->places->contains($to)))
-                throw new Exception(
-                    "At least one flow has an element that has not been added " .
-                    "to the transitions or places"
+                throw new BadInputException(
+                    "At least one flow has an element that has not been " .
+                    "added to the transitions or places"
                 );
         }
         $petrinet = new Petrinet($places, $transitions, $flowMap);

--- a/server/src/Exception/BadInputException.php
+++ b/server/src/Exception/BadInputException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Cora\Exception;
+
+use Throwable;
+use Exception;
+
+class BadInputException extends Exception {
+    public function __construct(string $message, ?Throwable $previous = null) {
+        parent::__construct($message, 400, $previous);
+    }
+}

--- a/server/src/Exception/InvalidSessionException.php
+++ b/server/src/Exception/InvalidSessionException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-use Exception;
-
-class InvalidSessionException extends Exception { }

--- a/server/src/Exception/MarkingNotFoundException.php
+++ b/server/src/Exception/MarkingNotFoundException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-use Exception;
-
-class MarkingNotFoundException extends Exception { }

--- a/server/src/Exception/NoInitialMarkingException.php
+++ b/server/src/Exception/NoInitialMarkingException.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-class NoInitialMarkingException { }

--- a/server/src/Exception/NoMetaLogException.php
+++ b/server/src/Exception/NoMetaLogException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-use Exception;
-
-class NoMetaLogException extends Exception { }

--- a/server/src/Exception/NoPetrinetException.php
+++ b/server/src/Exception/NoPetrinetException.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-class NoPetrinetException extends \Exception { }

--- a/server/src/Exception/NoSessionException.php
+++ b/server/src/Exception/NoSessionException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-use Exception;
-
-class NoSessionException extends Exception { }

--- a/server/src/Exception/NoSessionLogException.php
+++ b/server/src/Exception/NoSessionLogException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-use Exception;
-
-class NoSessionLogException extends Exception { }

--- a/server/src/Exception/NoUserException.php
+++ b/server/src/Exception/NoUserException.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-class NoUserException extends \Exception { }

--- a/server/src/Exception/NotFoundException.php
+++ b/server/src/Exception/NotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Cora\Exception;
+
+use Throwable;
+use Exception;
+
+class NotFoundException extends Exception {
+    public function __construct(string $message, ?Throwable $previous = null) {
+        parent::__construct($message, 404, $previous);
+    }
+}

--- a/server/src/Exception/PetrinetNotFoundException.php
+++ b/server/src/Exception/PetrinetNotFoundException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-use Exception;
-
-class PetrinetNotFoundException extends Exception { }

--- a/server/src/Exception/UserNotFoundException.php
+++ b/server/src/Exception/UserNotFoundException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-use Exception;
-
-class UserNotFoundException extends Exception { }

--- a/server/src/Exception/UserRegistrationException.php
+++ b/server/src/Exception/UserRegistrationException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Cora\Exception;
-
-use Exception;
-
-class UserRegistrationException extends Exception { }

--- a/server/src/Handler/Session/GetCurrentSession.php
+++ b/server/src/Handler/Session/GetCurrentSession.php
@@ -4,7 +4,9 @@ namespace Cora\Handler\Session;
 
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Message\ResponseInterface as Response;
+
 use Slim\Exception\HttpNotFoundException;
+use Slim\Exception\HttpBadRequestException;
 
 use Cora\Handler\AbstractHandler;
 use Cora\Service\GetSessionService;
@@ -16,7 +18,7 @@ class GetCurrentSession extends AbstractHandler {
         $parsedBody = $request->getParsedBody();
         $userId = $parsedBody["user_id"] ?? NULL;
         if (is_null($userId))
-            throw new HttpNotFoundException($request, "No user id supplied");
+            throw new HttpBadRequestException($request, "No user id supplied");
 
         $service = $this->container->get(GetSessionService::class);
         $result = $service->get($userId);

--- a/server/src/Handler/User/GetUser.php
+++ b/server/src/Handler/User/GetUser.php
@@ -21,9 +21,6 @@ class GetUser extends AbstractHandler {
         $service = $this->container->get(GetUserService::class);
         $user = $service->getUser($id);
 
-        if (is_null($user)) throw new HttpNotFoundException(
-            $request, "No user found for this id");
-
         $view = $this->getView();
         $view->setUser($user);
         $response->getBody()->write($view->render());

--- a/server/src/Middleware/HttpErrorMiddleware.php
+++ b/server/src/Middleware/HttpErrorMiddleware.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Cora\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface as Response;
+
+use Slim\Middleware\ErrorMiddleware;
+use Slim\Exception\HttpException;
+
+use Throwable;
+
+class HttpErrorMiddleware extends ErrorMiddleware {
+    public function handleException(Request $request, Throwable $exception): Response {
+        if ($exception->getCode() >= 400 && $exception->getCode() < 600) {
+            $exception = new HttpException(
+                $request,
+                $exception->getMessage(),
+                $exception->getCode(),
+                $exception
+            );
+            $exception->setTitle($exception->getMessage());
+        }
+
+        return parent::handleException($request, $exception);
+    }
+}

--- a/server/src/Service/GetFeedbackService.php
+++ b/server/src/Service/GetFeedbackService.php
@@ -7,7 +7,7 @@ use Cora\Repository\PetrinetRepository;
 use Cora\Repository\SessionRepository;
 use Cora\SystemChecker\CheckCoverabilityGraph;
 
-use Cora\Exception\InvalidSessionException;
+use Cora\Exception\NotFoundException;
 
 class GetFeedbackService {
     private $petrinetRepository, $sessionRepository;
@@ -21,8 +21,11 @@ class GetFeedbackService {
         $userId    = intval(filter_var($userId, FILTER_SANITIZE_NUMBER_INT));
         $sessionId = intval(filter_var($sessionId, FILTER_SANITIZE_NUMBER_INT));
 
-        if (!$this->sessionRepository->sessionExists($userId, $sessionId))
-            throw new InvalidSessionException("The session id is invalid");
+        if (!$this->sessionRepository->sessionExists($userId, $sessionId)) {
+            $message = "No session with id=$sessionId exists for user with "
+                     . "id=$userId";
+            throw new NotFoundException($message);
+        }
 
         $log        = $this->sessionRepository->getSessionLog($userId, $sessionId);
         $petrinetId = $log->getPetrinetId();

--- a/server/src/Service/GetPetrinetImageService.php
+++ b/server/src/Service/GetPetrinetImageService.php
@@ -7,7 +7,7 @@ use Cora\Domain\Petrinet\PetrinetInterface as IPetrinet;
 use Cora\Domain\Petrinet\Marking\MarkingInterface as IMarking;
 use Cora\Repository\PetrinetRepository;
 
-use Cora\Exception\PetrinetNotFoundException;
+use Cora\Exception\NotFoundException;
 
 class GetPetrinetImageService {
     private $repository;
@@ -19,13 +19,19 @@ class GetPetrinetImageService {
     public function get(int $pid, ?int $mid) {
         $pid = filter_var($pid, FILTER_SANITIZE_NUMBER_INT);
         if (!$this->repository->petrinetExists($pid))
-            throw new PetrinetNotFoundException(
-                "A Petri net with this id does not exist");
+            throw new NotFoundException(
+                "A Petri net with id=$pid does not exist");
         $mid = filter_var($mid, FILTER_SANITIZE_NUMBER_INT);
         $marking = NULL;
         $petrinet = $this->repository->getPetrinet($pid);
-        if ($this->repository->markingExists($mid))
+
+        if (!is_null($mid)) {
             $marking = $this->repository->getMarking($mid, $petrinet);
+            if (is_null($marking))
+                throw new NotFoundException(
+                    "Could not find marking with id=$mid");
+        }
+
         return $this->generateImage($petrinet, $marking);
     }
 

--- a/server/src/Service/GetPetrinetService.php
+++ b/server/src/Service/GetPetrinetService.php
@@ -4,6 +4,8 @@ namespace Cora\Service;
 
 use Cora\Domain\Petrinet\Marking\MarkingBuilder;
 use Cora\Domain\Petrinet\MarkedPetrinet;
+use Cora\Exception\NotFoundException;
+
 use Cora\Repository\PetrinetRepository;
 
 class GetPetrinetService {
@@ -20,8 +22,14 @@ class GetPetrinetService {
 
         if (is_null($petrinet))
             return NULL;
-        if (!is_null($mid))
+        if (!is_null($mid)) {
             $marking = $this->repository->getMarking($mid, $petrinet);
+            if (is_null($marking)) {
+                throw new NotFoundException("Could not find marking with " .
+                                            "id=$mid for Petri net with " .
+                                            "id=$pid");
+            }
+        }
         if (is_null($mid) || is_null($marking))
             $marking = $this->getEmptyMarking($petrinet);
 

--- a/server/src/Service/GetUserService.php
+++ b/server/src/Service/GetUserService.php
@@ -3,7 +3,7 @@
 namespace Cora\Service;
 
 use Cora\Repository\UserRepository;
-use Cora\Exception\UserNotFoundException;
+use Cora\Exception\NotFoundException;
 
 class GetUserService {
     protected $repository;
@@ -15,6 +15,11 @@ class GetUserService {
     public function getUser($id) {
         $id = filter_var($id, FILTER_SANITIZE_NUMBER_INT);
         $user = $this->repository->getUser('id', $id);
+
+        if (is_null($user)) {
+            throw new NotFoundException("Could not find user with id=$id");
+        }
+
         return $user;
     }
 }

--- a/server/src/Service/StartSessionService.php
+++ b/server/src/Service/StartSessionService.php
@@ -6,9 +6,7 @@ use Cora\Repository\SessionRepository as SessionRepo;
 use Cora\Repository\PetrinetRepository as PetriRepo;
 use Cora\Repository\UserRepository as UserRepo;
 
-use Cora\Exception\UserNotFoundException;
-use Cora\Exception\PetrinetNotFoundException;
-use Cora\Exception\MarkingNotFoundException;
+use Cora\Exception\NotFoundException;
 
 class StartSessionService {
     private $userRepository, $petrinetRepository, $sessionRepository;
@@ -25,13 +23,13 @@ class StartSessionService {
         $mid = filter_var($mid, FILTER_SANITIZE_NUMBER_INT);
 
         if (!$this->userRepository->userExists("id", $uid))
-            throw new UserNotFoundException(
+            throw new NotFoundException(
                 "Could not start session: user does not exist");
         if (!$this->petrinetRepository->petrinetExists($pid))
-            throw new PetrinetNotFoundException(
+            throw new NotFoundException(
                 "Could not start session: Petri net does not exist");
         if (!$this->petrinetRepository->markingExists($mid))
-            throw new MarkingNotFoundException(
+            throw new NotFoundException(
                 "Could not start session: Marking does not exist");
 
         return $this->sessionRepository->createNewSession($uid, $pid, $mid);


### PR DESCRIPTION
New middleware installed that wraps catches exceptions with codes between 400 and 600 and returns a response containing the exception message, and uses the code as the HTTP respones status. Removed superfluous exception types. Added generic types for frequent errors.